### PR TITLE
Implement CSV ingestion pipeline and tests

### DIFF
--- a/src/lib/ingestion/index.ts
+++ b/src/lib/ingestion/index.ts
@@ -1,0 +1,4 @@
+export * from './metrics';
+export * from './parser';
+export * from './run-ingestion';
+export * from './schema';

--- a/src/lib/ingestion/metrics.ts
+++ b/src/lib/ingestion/metrics.ts
@@ -1,0 +1,149 @@
+import { FlightRecord, Metrics } from './schema';
+
+export interface MetricsOptions {
+  sourceUrl: string;
+  totalRows: number;
+  issues: Metrics['issues'];
+  now?: Date;
+}
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+export function buildMetrics(flights: FlightRecord[], options: MetricsOptions): Metrics {
+  const { now = new Date(), sourceUrl, totalRows, issues } = options;
+
+  const totals = flights.reduce(
+    (acc, flight) => {
+      acc.flights += 1;
+      acc.totalHours += flight.totalTime;
+      acc.picHours += flight.pic;
+      acc.sicHours += flight.sic;
+      acc.dualHours += flight.dual;
+      acc.nightHours += flight.night;
+      acc.ifrHours += flight.ifr;
+      acc.approaches += flight.approaches;
+      acc.dayLandings += flight.landingsDay;
+      acc.nightLandings += flight.landingsNight;
+      return acc;
+    },
+    {
+      flights: 0,
+      totalHours: 0,
+      picHours: 0,
+      sicHours: 0,
+      dualHours: 0,
+      nightHours: 0,
+      ifrHours: 0,
+      approaches: 0,
+      dayLandings: 0,
+      nightLandings: 0,
+    },
+  );
+
+  const sortedFlights = [...flights].sort((a, b) => a.date.getTime() - b.date.getTime());
+  const latestFlight = sortedFlights.at(-1) ?? null;
+  const latestFlightDate = latestFlight ? latestFlight.date.toISOString() : null;
+  const daysSinceLastFlight = latestFlight
+    ? Math.floor((stripTime(now).getTime() - latestFlight.date.getTime()) / ONE_DAY_MS)
+    : null;
+  const stale = daysSinceLastFlight !== null ? daysSinceLastFlight >= 1 : true;
+
+  const rollingTotals = calculateRollingTotals(sortedFlights, now);
+  const byAircraft = calculateAircraftBreakdown(flights);
+  const byMonth = calculateMonthlyTotals(flights);
+
+  return {
+    updatedAt: now.toISOString(),
+    source: {
+      url: sourceUrl,
+      rows: {
+        total: totalRows,
+        valid: flights.length,
+        invalid: issues.length,
+      },
+    },
+    recency: {
+      latestFlightDate,
+      daysSinceLastFlight,
+      stale,
+    },
+    totals,
+    rollingTotals,
+    byAircraft,
+    byMonth,
+    issues,
+  };
+}
+
+function calculateRollingTotals(flights: FlightRecord[], now: Date) {
+  const nowTime = stripTime(now).getTime();
+  const thresholds = [7, 30, 90].map((days) => nowTime - days * ONE_DAY_MS);
+
+  const totals = {
+    last7Days: 0,
+    last30Days: 0,
+    last90Days: 0,
+  };
+
+  flights.forEach((flight) => {
+    const flightTime = flight.date.getTime();
+
+    if (flightTime >= thresholds[0]) {
+      totals.last7Days += flight.totalTime;
+    }
+
+    if (flightTime >= thresholds[1]) {
+      totals.last30Days += flight.totalTime;
+    }
+
+    if (flightTime >= thresholds[2]) {
+      totals.last90Days += flight.totalTime;
+    }
+  });
+
+  return totals;
+}
+
+function calculateAircraftBreakdown(flights: FlightRecord[]) {
+  return flights.reduce<Record<string, { flights: number; hours: number; picHours: number; nightHours: number }>>(
+    (acc, flight) => {
+      const key = flight.aircraftModel;
+      if (!acc[key]) {
+        acc[key] = {
+          flights: 0,
+          hours: 0,
+          picHours: 0,
+          nightHours: 0,
+        };
+      }
+
+      acc[key].flights += 1;
+      acc[key].hours += flight.totalTime;
+      acc[key].picHours += flight.pic;
+      acc[key].nightHours += flight.night;
+      return acc;
+    },
+    {},
+  );
+}
+
+function calculateMonthlyTotals(flights: FlightRecord[]) {
+  const map = new Map<string, { flights: number; hours: number }>();
+
+  flights.forEach((flight) => {
+    const monthKey = `${flight.date.getUTCFullYear()}-${String(flight.date.getUTCMonth() + 1).padStart(2, '0')}`;
+    const bucket = map.get(monthKey) ?? { flights: 0, hours: 0 };
+    bucket.flights += 1;
+    bucket.hours += flight.totalTime;
+    map.set(monthKey, bucket);
+  });
+
+  return Array.from(map.entries())
+    .sort(([a], [b]) => (a < b ? -1 : 1))
+    .map(([month, totals]) => ({ month, ...totals }));
+}
+
+function stripTime(date: Date): Date {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+}
+

--- a/src/lib/ingestion/parser.ts
+++ b/src/lib/ingestion/parser.ts
@@ -1,0 +1,131 @@
+import { parse } from 'csv-parse/sync';
+import { RawFlightSchema, FlightSchema, type FlightRecord, type RawFlightRecord } from './schema';
+
+type KeyAlias = keyof RawFlightRecord;
+
+const HEADER_ALIASES: Record<string, KeyAlias> = {
+  date: 'date',
+  flightdate: 'date',
+  'flight date': 'date',
+  aircraft: 'aircraftModel',
+  'aircraft model': 'aircraftModel',
+  'aircraft type': 'aircraftModel',
+  aircraftmodel: 'aircraftModel',
+  tail: 'tailNumber',
+  tailnumber: 'tailNumber',
+  registration: 'tailNumber',
+  from: 'origin',
+  origin: 'origin',
+  dep: 'origin',
+  departure: 'origin',
+  to: 'destination',
+  destination: 'destination',
+  arr: 'destination',
+  arrival: 'destination',
+  number: 'flightNumber',
+  'flight number': 'flightNumber',
+  total: 'totalTime',
+  'total time': 'totalTime',
+  duration: 'totalTime',
+  hours: 'totalTime',
+  pic: 'pic',
+  'pic time': 'pic',
+  command: 'pic',
+  sic: 'sic',
+  copilot: 'sic',
+  dual: 'dual',
+  instruction: 'dual',
+  night: 'night',
+  ifr: 'ifr',
+  approaches: 'approaches',
+  appr: 'approaches',
+  'landings day': 'landingsDay',
+  'landings (day)': 'landingsDay',
+  'day landings': 'landingsDay',
+  landings: 'landingsDay',
+  'landings night': 'landingsNight',
+  'landings (night)': 'landingsNight',
+  'night landings': 'landingsNight',
+  remarks: 'remarks',
+  notes: 'remarks',
+};
+
+export interface ParseOptions {
+  strictColumns?: boolean;
+}
+
+export interface ParseResult {
+  flights: FlightRecord[];
+  issues: Array<{
+    rowNumber: number;
+    errors: string[];
+  }>;
+  totalRows: number;
+}
+
+export function parseCsvFlights(csv: string, options: ParseOptions = {}): ParseResult {
+  const rows = parse(csv, {
+    columns: true,
+    skip_empty_lines: true,
+    trim: true,
+  }) as Record<string, string>[];
+
+  const flights: FlightRecord[] = [];
+  const issues: ParseResult['issues'] = [];
+
+  rows.forEach((row, index) => {
+    const normalized = normalizeRow(row, options.strictColumns);
+    const validation = FlightSchema.safeParse(normalized);
+
+    if (validation.success) {
+      flights.push(validation.data);
+      return;
+    }
+
+    const rawValidation = RawFlightSchema.safeParse(normalized);
+    const messages = validation.error.issues.map((issue) => issue.message);
+
+    if (!rawValidation.success) {
+      messages.push(...rawValidation.error.issues.map((issue) => issue.message));
+    }
+
+    issues.push({
+      rowNumber: index + 2,
+      errors: dedupe(messages),
+    });
+  });
+
+  return {
+    flights,
+    issues,
+    totalRows: rows.length,
+  };
+}
+
+function normalizeRow(row: Record<string, string>, strictColumns = false): RawFlightRecord {
+  const normalized: RawFlightRecord = {};
+
+  Object.entries(row).forEach(([rawKey, rawValue]) => {
+    const alias = HEADER_ALIASES[normalizeKey(rawKey)];
+
+    if (!alias) {
+      if (strictColumns) {
+        normalized[rawKey as keyof RawFlightRecord] = rawValue;
+      }
+      return;
+    }
+
+    normalized[alias] = rawValue;
+  });
+
+  return normalized;
+}
+
+function normalizeKey(key: string): string {
+  return key.replace(/[^a-z0-9]+/gi, '').toLowerCase();
+}
+
+function dedupe(values: string[]): string[] {
+  return Array.from(new Set(values.filter(Boolean)));
+}
+

--- a/src/lib/ingestion/run-ingestion.ts
+++ b/src/lib/ingestion/run-ingestion.ts
@@ -1,0 +1,65 @@
+import { put, type PutBlobResult } from '@vercel/blob';
+import { buildMetrics } from './metrics';
+import { parseCsvFlights } from './parser';
+import type { Metrics } from './schema';
+
+export interface RunIngestionOptions {
+  dataSourceUrl: string;
+  blobKey?: string;
+  fetchImpl?: typeof fetch;
+  putImpl?: typeof put;
+  now?: Date;
+  dryRun?: boolean;
+}
+
+export interface RunIngestionResult {
+  metrics: Metrics;
+  blob?: PutBlobResult;
+}
+
+export async function runIngestion(options: RunIngestionOptions): Promise<RunIngestionResult> {
+  const {
+    dataSourceUrl,
+    blobKey = 'metrics.json',
+    fetchImpl = fetch,
+    putImpl,
+    now = new Date(),
+    dryRun = false,
+  } = options;
+
+  const response = await fetchImpl(dataSourceUrl);
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch data source: ${response.status} ${response.statusText}`);
+  }
+
+  const csv = await response.text();
+  const parseResult = parseCsvFlights(csv);
+
+  if (parseResult.flights.length === 0) {
+    throw new Error('No valid flight data found in the data source');
+  }
+
+  const metrics = buildMetrics(parseResult.flights, {
+    sourceUrl: dataSourceUrl,
+    totalRows: parseResult.totalRows,
+    issues: parseResult.issues,
+    now,
+  });
+
+  let blob: PutBlobResult | undefined;
+
+  if (!dryRun) {
+    const writer = putImpl ?? put;
+    blob = await writer(blobKey, JSON.stringify(metrics, null, 2), {
+      access: 'public',
+      contentType: 'application/json',
+    });
+  }
+
+  return {
+    metrics,
+    blob,
+  };
+}
+

--- a/src/lib/ingestion/schema.ts
+++ b/src/lib/ingestion/schema.ts
@@ -1,0 +1,272 @@
+import { z } from 'zod';
+
+const NumberFromCsv = z.preprocess((value) => {
+  if (value === null || value === undefined) {
+    return 0;
+  }
+
+  if (typeof value === 'number') {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+
+    if (!trimmed) {
+      return 0;
+    }
+
+    const normalized = trimmed.replace(/,/g, '');
+    const parsed = Number(normalized);
+
+    if (Number.isNaN(parsed)) {
+      return value;
+    }
+
+    return parsed;
+  }
+
+  return value;
+}, z.number({ invalid_type_error: 'Expected numeric value' }));
+
+const NonNegativeNumberFromCsv = NumberFromCsv.refine((value) => value >= 0, {
+  message: 'Expected a non-negative number',
+});
+
+const DateFromCsv = z.preprocess((value) => {
+  if (value instanceof Date) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+
+    if (!trimmed) {
+      return value;
+    }
+
+    const normalized = trimmed.replace(/\s+/g, ' ');
+
+    const parsed = normalizeDate(normalized);
+
+    return parsed ?? value;
+  }
+
+  return value;
+}, z
+  .date({ invalid_type_error: 'Expected a valid date string' })
+  .transform((date) => normalizeToUtc(date)));
+
+type RawFlightRecord = {
+  date?: string;
+  aircraftModel?: string;
+  tailNumber?: string;
+  origin?: string;
+  destination?: string;
+  flightNumber?: string;
+  remarks?: string;
+  totalTime?: string | number;
+  pic?: string | number;
+  sic?: string | number;
+  dual?: string | number;
+  night?: string | number;
+  ifr?: string | number;
+  approaches?: string | number;
+  landingsDay?: string | number;
+  landingsNight?: string | number;
+};
+
+export const RawFlightSchema: z.ZodType<RawFlightRecord> = z.object({
+  date: z.string().optional(),
+  aircraftModel: z.string().optional(),
+  tailNumber: z.string().optional(),
+  origin: z.string().optional(),
+  destination: z.string().optional(),
+  flightNumber: z.string().optional(),
+  remarks: z.string().optional(),
+  totalTime: z.union([z.string(), z.number()]).optional(),
+  pic: z.union([z.string(), z.number()]).optional(),
+  sic: z.union([z.string(), z.number()]).optional(),
+  dual: z.union([z.string(), z.number()]).optional(),
+  night: z.union([z.string(), z.number()]).optional(),
+  ifr: z.union([z.string(), z.number()]).optional(),
+  approaches: z.union([z.string(), z.number()]).optional(),
+  landingsDay: z.union([z.string(), z.number()]).optional(),
+  landingsNight: z.union([z.string(), z.number()]).optional(),
+});
+
+export const FlightSchema = z
+  .object({
+    date: DateFromCsv,
+    aircraftModel: z.string().min(1, 'Aircraft model is required'),
+    tailNumber: z.string().optional(),
+    origin: z.string().min(1, 'Origin is required'),
+    destination: z.string().min(1, 'Destination is required'),
+    flightNumber: z.string().optional(),
+    remarks: z.string().optional(),
+    totalTime: NonNegativeNumberFromCsv,
+    pic: NonNegativeNumberFromCsv.default(0),
+    sic: NonNegativeNumberFromCsv.default(0),
+    dual: NonNegativeNumberFromCsv.default(0),
+    night: NonNegativeNumberFromCsv.default(0),
+    ifr: NonNegativeNumberFromCsv.default(0),
+    approaches: NonNegativeNumberFromCsv.default(0),
+    landingsDay: NonNegativeNumberFromCsv.default(0),
+    landingsNight: NonNegativeNumberFromCsv.default(0),
+  })
+  .refine((data) => data.totalTime >= data.pic + data.sic, {
+    message: 'Total time cannot be less than PIC + SIC time',
+    path: ['totalTime'],
+  });
+
+export type FlightRecord = z.infer<typeof FlightSchema>;
+
+export interface Metrics {
+  updatedAt: string;
+  source: {
+    url: string;
+    rows: {
+      total: number;
+      valid: number;
+      invalid: number;
+    };
+  };
+  recency: {
+    latestFlightDate: string | null;
+    daysSinceLastFlight: number | null;
+    stale: boolean;
+  };
+  totals: {
+    flights: number;
+    totalHours: number;
+    picHours: number;
+    sicHours: number;
+    dualHours: number;
+    nightHours: number;
+    ifrHours: number;
+    approaches: number;
+    dayLandings: number;
+    nightLandings: number;
+  };
+  rollingTotals: {
+    last7Days: number;
+    last30Days: number;
+    last90Days: number;
+  };
+  byAircraft: Record<
+    string,
+    {
+      flights: number;
+      hours: number;
+      picHours: number;
+      nightHours: number;
+    }
+  >;
+  byMonth: Array<{
+    month: string;
+    flights: number;
+    hours: number;
+  }>;
+  issues: Array<{
+    rowNumber: number;
+    errors: string[];
+  }>;
+}
+
+
+export const MetricsSchema: z.ZodType<Metrics> = z.object({
+  updatedAt: z.string(),
+  source: z.object({
+    url: z.string().url(),
+    rows: z.object({
+      total: z.number().int().nonnegative(),
+      valid: z.number().int().nonnegative(),
+      invalid: z.number().int().nonnegative(),
+    }),
+  }),
+  recency: z.object({
+    latestFlightDate: z.string().nullable(),
+    daysSinceLastFlight: z.number().nullable(),
+    stale: z.boolean(),
+  }),
+  totals: z.object({
+    flights: z.number().int().nonnegative(),
+    totalHours: z.number().nonnegative(),
+    picHours: z.number().nonnegative(),
+    sicHours: z.number().nonnegative(),
+    dualHours: z.number().nonnegative(),
+    nightHours: z.number().nonnegative(),
+    ifrHours: z.number().nonnegative(),
+    approaches: z.number().nonnegative(),
+    dayLandings: z.number().nonnegative(),
+    nightLandings: z.number().nonnegative(),
+  }),
+  rollingTotals: z.object({
+    last7Days: z.number().nonnegative(),
+    last30Days: z.number().nonnegative(),
+    last90Days: z.number().nonnegative(),
+  }),
+  byAircraft: z.record(
+    z.object({
+      flights: z.number().int().nonnegative(),
+      hours: z.number().nonnegative(),
+      picHours: z.number().nonnegative(),
+      nightHours: z.number().nonnegative(),
+    }),
+  ),
+  byMonth: z
+    .array(
+      z.object({
+        month: z.string(),
+        flights: z.number().int().nonnegative(),
+        hours: z.number().nonnegative(),
+      }),
+    ),
+  issues: z.array(
+    z.object({
+      rowNumber: z.number().int().positive(),
+      errors: z.array(z.string()).nonempty(),
+    }),
+  ),
+});
+
+function normalizeDate(value: string): Date | null {
+  const isoLike = Date.parse(value);
+  if (!Number.isNaN(isoLike)) {
+    return new Date(isoLike);
+  }
+
+  const [month, day, year] = value.split(/[\/-]/).map((part) => part.trim());
+
+  if (month && day && year) {
+    const normalizedYear = normalizeYear(year);
+    const candidate = new Date(`${normalizedYear}-${pad(month)}-${pad(day)}T00:00:00Z`);
+    if (!Number.isNaN(candidate.getTime())) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+function normalizeYear(year: string): string {
+  if (year.length === 2) {
+    const numeric = Number(year);
+    if (numeric <= 68) {
+      return `20${year.padStart(2, '0')}`;
+    }
+    return `19${year.padStart(2, '0')}`;
+  }
+
+  return year;
+}
+
+function pad(value: string): string {
+  return value.padStart(2, '0');
+}
+
+function normalizeToUtc(date: Date): Date {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+}
+
+export type { RawFlightRecord };

--- a/tests/ingestion/ingestion.test.ts
+++ b/tests/ingestion/ingestion.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildMetrics, parseCsvFlights, runIngestion } from '@/src/lib/ingestion';
+
+type PutFunction = (typeof import('@vercel/blob'))['put'];
+
+const SAMPLE_CSV = `Date,Aircraft,Registration,From,To,Total Time,PIC,SIC,Night,IFR,Approaches,Landings (Day),Landings (Night),Remarks
+2024-03-01,C172,N12345,KPDX,KSFO,2.5,2.5,0,0.5,1,2,1,0,Training flight
+2024-02-15,SR22,N54321,KSFO,KRNO,1.2,1.2,0,0,0.2,0,1,0,Proficiency
+2024-02-10,C172,,KBUR,KVNY,-1,0,0,0,0,0,0,0,Data error`;
+
+describe('parseCsvFlights', () => {
+  it('parses valid rows and reports issues for invalid ones', () => {
+    const result = parseCsvFlights(SAMPLE_CSV);
+
+    expect(result.flights).toHaveLength(2);
+    expect(result.issues).toHaveLength(1);
+    expect(result.totalRows).toBe(3);
+
+    expect(result.flights[0]).toMatchObject({
+      aircraftModel: 'C172',
+      origin: 'KPDX',
+      destination: 'KSFO',
+      totalTime: 2.5,
+      pic: 2.5,
+    });
+
+    expect(result.issues[0]).toEqual(
+      expect.objectContaining({
+        rowNumber: 4,
+        errors: expect.arrayContaining(['Expected a non-negative number']),
+      }),
+    );
+  });
+});
+
+describe('buildMetrics', () => {
+  it('summarises totals, breakdowns and recency metadata', () => {
+    const now = new Date('2024-03-10T12:00:00Z');
+    const { flights, issues, totalRows } = parseCsvFlights(SAMPLE_CSV);
+    const metrics = buildMetrics(flights, {
+      sourceUrl: 'https://example.com/data.csv',
+      totalRows,
+      issues,
+      now,
+    });
+
+    expect(metrics.updatedAt).toBe(now.toISOString());
+    expect(metrics.totals.flights).toBe(2);
+    expect(metrics.totals.totalHours).toBeCloseTo(3.7, 5);
+    expect(metrics.totals.picHours).toBeCloseTo(3.7, 5);
+    expect(metrics.rollingTotals.last30Days).toBeCloseTo(3.7, 5);
+    expect(metrics.rollingTotals.last7Days).toBeCloseTo(2.5, 5);
+    expect(metrics.byAircraft.C172.hours).toBeCloseTo(2.5, 5);
+    expect(metrics.byAircraft.SR22.hours).toBeCloseTo(1.2, 5);
+    expect(metrics.byMonth).toContainEqual({ month: '2024-02', flights: 1, hours: 1.2 });
+    expect(metrics.byMonth).toContainEqual({ month: '2024-03', flights: 1, hours: 2.5 });
+    expect(metrics.source.rows.invalid).toBe(1);
+    expect(metrics.issues[0].rowNumber).toBe(4);
+    expect(metrics.recency.stale).toBe(true);
+  });
+});
+
+describe('runIngestion', () => {
+  it('fetches, validates and persists metrics to the blob store', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () => SAMPLE_CSV,
+    });
+    const putMock = vi.fn().mockResolvedValue({ url: 'https://blob/metrics.json' });
+
+    const now = new Date('2024-03-10T12:00:00Z');
+    const result = await runIngestion({
+      dataSourceUrl: 'https://example.com/data.csv',
+      fetchImpl: fetchMock,
+      putImpl: putMock as unknown as PutFunction,
+      now,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith('https://example.com/data.csv');
+    expect(putMock).toHaveBeenCalledWith(
+      'metrics.json',
+      expect.any(String),
+      expect.objectContaining({ contentType: 'application/json' }),
+    );
+
+    const payload = JSON.parse(putMock.mock.calls[0][1]);
+    expect(payload.source.rows.valid).toBe(2);
+    expect(payload.source.rows.invalid).toBe(1);
+    expect(result.metrics.updatedAt).toBe(now.toISOString());
+    expect(result.blob).toEqual({ url: 'https://blob/metrics.json' });
+    expect(putMock.mock.calls[0][2]).toMatchObject({ access: 'public' });
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';


### PR DESCRIPTION
## Summary
- add reusable ingestion schema utilities for validating CSV flight data
- implement parsing, metrics aggregation, and blob persistence logic
- cover ingestion flow with Vitest tests exercising parsing, metrics, and persistence

## Testing
- `npm test` *(fails: vitest binary unavailable because npm install cannot reach registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68d53c66db5c8331a7a7c86b45e555ec